### PR TITLE
Link names

### DIFF
--- a/slack.go
+++ b/slack.go
@@ -23,8 +23,9 @@ func (s *Slack) onMessage(message *Message) error {
 		message.Group,
 		message.Body,
 		slack.PostMessageParameters{
-			Username: s.Name,
-			IconURL:  s.Icon,
+			Username:  s.Name,
+			IconURL:   s.Icon,
+			LinkNames: 1,
 		},
 	)
 


### PR DESCRIPTION
Set `link_names` as 1 makes user/channel names to be linked.
https://api.slack.com/methods/chat.postMessage
## before

![](http://i.gyazo.com/231cabb876d62f13cd964fbe88b45aaa.png)
## after

![](http://i.gyazo.com/2e8e4cc28ba4c319f86722e361de24b8.png)

---

Additionally, this make clients to be notified in this configuration.

![](http://gyazo-yuyat.herokuapp.com/4a6997bdd9ea7b6f7222deee39a41312.png)
