### PR TITLE
Add attachment extention

### DIFF
--- a/httpd.go
+++ b/httpd.go
@@ -13,8 +13,21 @@ type Httpd struct {
 }
 
 type Param struct {
-	Channel string `form:"channel" binding:"required"`
-	Message string `form:"message"`
+	Channel    string `form:"channel" binding:"required"`
+	Message    string `form:"message"`
+	Name       string `form:"name"`
+	Icon       string `form:"icon"`
+	Color      string `form:"color"`
+	Pretext    string `form:"pretext"`
+	AuthorName string `form:"author_name"`
+	AuthorLink string `form:"author_link"`
+	AuthorIcon string `form:"author_icon"`
+	Title      string `form:"title"`
+	TitleLink  string `form:"title_link"`
+	Text       string `form:"text"`
+	ImageURL   string `form:"image_url"`
+	Parse      string `form:"parse"`
+	Manual     bool   `form:"manual"`
 }
 
 func NewHttpd(host string, port int) *Httpd {
@@ -34,7 +47,23 @@ func (h *Httpd) Run() {
 
 func messageHandler(p Param) (int, string) {
 	ch := make(chan error, 1)
-	go MessageBus.Publish(NewMessage(p.Channel, p.Message, ch))
+
+	newMessage := NewMessage(p.Channel, p.Message, ch)
+	newMessage.Name = p.Name
+	newMessage.Icon = p.Icon
+	newMessage.Color = p.Color
+	newMessage.Pretext = p.Pretext
+	newMessage.AuthorName = p.AuthorName
+	newMessage.AuthorLink = p.AuthorLink
+	newMessage.AuthorIcon = p.AuthorIcon
+	newMessage.Title = p.Title
+	newMessage.TitleLink = p.TitleLink
+	newMessage.Text = p.Text
+	newMessage.ImageURL = p.ImageURL
+	newMessage.Parse = p.Parse
+	newMessage.Manual = p.Manual
+
+	go MessageBus.Publish(newMessage)
 	err := <-ch
 
 	if err != nil {

--- a/httpd.go
+++ b/httpd.go
@@ -13,21 +13,24 @@ type Httpd struct {
 }
 
 type Param struct {
-	Channel    string `form:"channel" binding:"required"`
-	Message    string `form:"message"`
-	Name       string `form:"name"`
-	Icon       string `form:"icon"`
-	Color      string `form:"color"`
-	Pretext    string `form:"pretext"`
-	AuthorName string `form:"author_name"`
-	AuthorLink string `form:"author_link"`
-	AuthorIcon string `form:"author_icon"`
-	Title      string `form:"title"`
-	TitleLink  string `form:"title_link"`
-	Text       string `form:"text"`
-	ImageURL   string `form:"image_url"`
-	Parse      string `form:"parse"`
-	Manual     bool   `form:"manual"`
+	Channel    string   `form:"channel" binding:"required"`
+	Message    string   `form:"message"`
+	Name       string   `form:"name"`
+	Icon       string   `form:"icon"`
+	Fallback   string   `form:"fallback"`
+	Color      string   `form:"color"`
+	Pretext    string   `form:"pretext"`
+	AuthorName string   `form:"author_name"`
+	AuthorLink string   `form:"author_link"`
+	AuthorIcon string   `form:"author_icon"`
+	Title      string   `form:"title"`
+	TitleLink  string   `form:"title_link"`
+	Text       string   `form:"text"`
+	FieldTitle []string `form:"field_title[]"`
+	FieldValue []string `form:"field_value[]"`
+	FieldShort []bool   `form:"field_short[]"`
+	ImageURL   string   `form:"image_url"`
+	Manual     bool     `form:"manual"`
 }
 
 func NewHttpd(host string, port int) *Httpd {
@@ -47,23 +50,7 @@ func (h *Httpd) Run() {
 
 func messageHandler(p Param) (int, string) {
 	ch := make(chan error, 1)
-
-	newMessage := NewMessage(p.Channel, p.Message, ch)
-	newMessage.Name = p.Name
-	newMessage.Icon = p.Icon
-	newMessage.Color = p.Color
-	newMessage.Pretext = p.Pretext
-	newMessage.AuthorName = p.AuthorName
-	newMessage.AuthorLink = p.AuthorLink
-	newMessage.AuthorIcon = p.AuthorIcon
-	newMessage.Title = p.Title
-	newMessage.TitleLink = p.TitleLink
-	newMessage.Text = p.Text
-	newMessage.ImageURL = p.ImageURL
-	newMessage.Parse = p.Parse
-	newMessage.Manual = p.Manual
-
-	go MessageBus.Publish(newMessage)
+	go MessageBus.Publish(NewMessage(p, ch))
 	err := <-ch
 
 	if err != nil {

--- a/message.go
+++ b/message.go
@@ -1,9 +1,22 @@
 package main
 
 type Message struct {
-	Group  string
-	Body   string
-	Result chan error
+	Group      string
+	Body       string
+	Name       string
+	Icon       string
+	Color      string
+	Pretext    string
+	AuthorName string
+	AuthorLink string
+	AuthorIcon string
+	Title      string
+	TitleLink  string
+	Text       string
+	ImageURL   string
+	Parse      string
+	Manual     bool
+	Result     chan error
 }
 
 func NewMessage(group, body string, ch chan error) *Message {

--- a/message.go
+++ b/message.go
@@ -1,10 +1,16 @@
 package main
 
 type Message struct {
-	Group      string
-	Body       string
+	Channel    string
+	Message    string
 	Name       string
 	Icon       string
+	Attachment *Attachment
+	Manual     bool
+	Result     chan error
+}
+
+type Attachment struct {
 	Color      string
 	Pretext    string
 	AuthorName string
@@ -12,17 +18,94 @@ type Message struct {
 	AuthorIcon string
 	Title      string
 	TitleLink  string
+	Fallback   string
 	Text       string
+	Fields     []Field
 	ImageURL   string
-	Parse      string
-	Manual     bool
-	Result     chan error
 }
 
-func NewMessage(group, body string, ch chan error) *Message {
-	return &Message{
-		Group:  group,
-		Body:   body,
-		Result: ch,
+type Field struct {
+	Title string
+	Value string
+	Short bool
+}
+
+func NewMessage(p Param, ch chan error) *Message {
+	attachment := NewAttachment(p)
+
+	message := Message{
+		Channel:    p.Channel,
+		Message:    p.Message,
+		Name:       p.Name,
+		Icon:       p.Icon,
+		Attachment: attachment,
+		Manual:     p.Manual,
+		Result:     ch,
 	}
+
+	if message.Name == "" {
+		message.Name = name
+	}
+	if message.Icon == "" {
+		message.Icon = icon
+	}
+
+	if message.Manual == false {
+		if message.Message != "" && attachment.Text == "" && attachment.Color != "" {
+			attachment.Text = message.Message
+			message.Message = ""
+		}
+		if attachment.Text != "" && attachment.Fallback == "" {
+			attachment.Fallback = attachment.Text
+		}
+	}
+
+	return &message
+}
+
+func NewAttachment(p Param) *Attachment {
+	attachment := Attachment{
+		Fallback:   p.Fallback,
+		Color:      p.Color,
+		Pretext:    p.Pretext,
+		AuthorName: p.AuthorName,
+		AuthorLink: p.AuthorLink,
+		AuthorIcon: p.AuthorIcon,
+		Title:      p.Title,
+		TitleLink:  p.TitleLink,
+		Text:       p.Text,
+		ImageURL:   p.ImageURL,
+	}
+
+	attachment.Fields = NewFields(p)
+
+	return &attachment
+}
+
+func NewFields(p Param) []Field {
+	field_title_max := len(p.FieldTitle)
+	field_value_max := len(p.FieldValue)
+	field_short_max := len(p.FieldShort)
+
+	field_max := 0
+	if field_title_max >= field_value_max {
+		field_max = field_title_max
+	} else {
+		field_max = field_value_max
+	}
+
+	fields := make([]Field, field_max)
+	for i := range fields {
+		if i < field_title_max {
+			fields[i].Title = p.FieldTitle[i]
+		}
+		if i < field_value_max {
+			fields[i].Value = p.FieldValue[i]
+		}
+		if i < field_short_max {
+			fields[i].Short = p.FieldShort[i]
+		}
+	}
+
+	return fields
 }

--- a/slack.go
+++ b/slack.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"github.com/nlopes/slack"
+	"regexp"
 )
 
 type Slack struct {
@@ -19,15 +20,59 @@ func NewSlack(name, icon, token string) *Slack {
 }
 
 func (s *Slack) onMessage(message *Message) error {
-	_, _, err := s.Client.PostMessage(
-		message.Group,
-		message.Body,
-		slack.PostMessageParameters{
-			Username:  s.Name,
-			IconURL:   s.Icon,
-			LinkNames: 1,
-		},
-	)
+	postMessage := slack.PostMessageParameters{
+		LinkNames: 1,
+	}
 
+	// Set bot name
+	if message.Name != "" {
+		postMessage.Username = message.Name
+	} else {
+		postMessage.Username = s.Name
+	}
+
+	// Set bot Icon
+	iconString := ""
+	if message.Icon != "" {
+		iconString = message.Icon
+	} else {
+		iconString = s.Icon
+	}
+
+	// Switch IconURL or IconEmoji
+	re := regexp.MustCompile("^:.*:$")
+	if re.MatchString(iconString) {
+		postMessage.IconEmoji = iconString
+	} else {
+		postMessage.IconURL = iconString
+	}
+
+	messageText := message.Body
+	attachment := slack.Attachment{}
+
+	attachment.Color = message.Color
+	attachment.Pretext = message.Pretext
+	attachment.AuthorName = message.AuthorName
+	attachment.AuthorLink = message.AuthorLink
+	attachment.AuthorIcon = message.AuthorIcon
+	attachment.Text = message.Text
+	attachment.Fallback = message.Text
+	attachment.Title = message.Title
+	attachment.TitleLink = message.TitleLink
+	attachment.ImageURL = message.ImageURL
+
+	// Automatic actions
+	if message.Manual == false {
+		if attachment.Color != "" && message.Body != "" && message.Text == "" {
+			messageText = ""
+			attachment.Text = message.Body
+			attachment.Fallback = message.Body
+		}
+	}
+
+	postMessage.Attachments = []slack.Attachment{attachment}
+	postMessage.Parse = message.Parse
+
+	_, _, err := s.Client.PostMessage(message.Group, messageText, postMessage)
 	return err
 }


### PR DESCRIPTION
### 概要
- BOT の アイコン と 名前 を変更可能にしました。
- Slack に投稿する際に Attachment を付加できるようにしました。
  - ref: https://api.slack.com/docs/attachments
### 仕様
- 1 POSTに1つの `Attachment` を添付して投稿できます。
  - `Attachment` 中には 複数の `Field` を追加することができます。
  - ライブラリの制限により`Attachment` 中で Markdown を利用することができません。
- `icon` には画像のURL、もしくは絵文字を利用指定することができます。
- `text` の指定がない場合に `color` を指定をすると、`message` はAttachmentとして処理されます。
  - `manual` に `true` を指定するとこの処理を行いません。
### サンプル

![image](https://cloud.githubusercontent.com/assets/1488898/7218128/fc67e922-e695-11e4-8a60-91cbabce7a82.png)

サンプルのようなPOSTをするには下記のようにコマンドを組み立てます。

``` sh
curl localhost:4979/notice \
-d "channel=#bot_test" \
-d "message=*Hello* \`shachikun\`" \
-d "icon=:orca:" \
-d "name=shachikun" \
-d "color=#3498db" \
-d "pretext=Tell you about slack :ocean:" \
-d "author_name=Slack" \
-d "author_icon=https://slack.global.ssl.fastly.net/272a/img/icons/favicon-32.png" \
-d "author_link=https://slack.com/" \
-d "title=Slack (software)" \
-d "title_link=http://ja.wikipedia.org/wiki/Slack_(software)" \
-d "text=Slack is a team communication tool co-founded by Stewart Butterfield, Eric Costello, Cal Henderson, and Serguei Mourachov. Slack began as an internal tool used by their company Tiny Speck in the development of Glitch, the defunct online game. Slack was launched in August, 2013, and signed up 8000 customers within 24 hours of launch." \
-d "image_url=https://slack.global.ssl.fastly.net/558b/img/slack_logo.png" \
-d "field_title[]=:star2: Features" \
-d "field_value[]=Slack offers persistent chat rooms organized by topic, as well as private groups and direct messaging." \
-d "field_short[]=true" \
-d "field_title[]=:package: Platforms" \
-d "field_value[]=Slack provides apps for Mac, iOS, and Android, and released an official Windows client on 18 March 2015." \
-d "field_short[]=true"
```
