### PR TITLE
Add markdown support

### DIFF
--- a/message.go
+++ b/message.go
@@ -30,34 +30,66 @@ type Field struct {
 	Short bool
 }
 
+func (p *Param) HasAttachment() bool {
+	if (p.Text != "") ||
+		(p.Color != "") ||
+		(p.Fallback != "") ||
+		(p.Pretext != "") ||
+		(p.AuthorName != "") ||
+		(p.AuthorLink != "") ||
+		(p.AuthorIcon != "") ||
+		(p.Title != "") ||
+		(p.TitleLink != "") ||
+		(p.ImageURL != "") ||
+		(len(p.FieldTitle) > 0) ||
+		(len(p.FieldValue) > 0) {
+		return true
+	}
+
+	return false
+}
+
+func (p *Param) HasField() bool {
+	if (len(p.FieldTitle) > 0) || (len(p.FieldValue) > 0) {
+		return true
+	}
+
+	return false
+}
+
+func (p *Param) Adjust() {
+	if p.Name == "" {
+		p.Name = name
+	}
+	if p.Icon == "" {
+		p.Icon = icon
+	}
+
+	if p.Manual == false {
+		if p.Message != "" && p.Text == "" && p.Color != "" {
+			p.Text = p.Message
+			p.Message = ""
+		}
+		if p.Text != "" && p.Fallback == "" {
+			p.Fallback = p.Text
+		}
+	}
+}
+
 func NewMessage(p Param, ch chan error) *Message {
-	attachment := NewAttachment(p)
+	p.Adjust()
 
 	message := Message{
-		Channel:    p.Channel,
-		Message:    p.Message,
-		Name:       p.Name,
-		Icon:       p.Icon,
-		Attachment: attachment,
-		Manual:     p.Manual,
-		Result:     ch,
+		Channel: p.Channel,
+		Message: p.Message,
+		Name:    p.Name,
+		Icon:    p.Icon,
+		Manual:  p.Manual,
+		Result:  ch,
 	}
 
-	if message.Name == "" {
-		message.Name = name
-	}
-	if message.Icon == "" {
-		message.Icon = icon
-	}
-
-	if message.Manual == false {
-		if message.Message != "" && attachment.Text == "" && attachment.Color != "" {
-			attachment.Text = message.Message
-			message.Message = ""
-		}
-		if attachment.Text != "" && attachment.Fallback == "" {
-			attachment.Fallback = attachment.Text
-		}
+	if p.HasAttachment() {
+		message.Attachment = NewAttachment(p)
 	}
 
 	return &message
@@ -77,7 +109,9 @@ func NewAttachment(p Param) *Attachment {
 		ImageURL:   p.ImageURL,
 	}
 
-	attachment.Fields = NewFields(p)
+	if p.HasField() {
+		attachment.Fields = NewFields(p)
+	}
 
 	return &attachment
 }

--- a/slack.go
+++ b/slack.go
@@ -20,32 +20,9 @@ func NewSlack(name, icon, token string) *Slack {
 }
 
 func (s *Slack) onMessage(message *Message) error {
-	fields := make([]slack.AttachmentField, len(message.Attachment.Fields))
-	for i := range fields {
-		fields[i].Title = message.Attachment.Fields[i].Title
-		fields[i].Value = message.Attachment.Fields[i].Value
-		fields[i].Short = message.Attachment.Fields[i].Short
-	}
-
-	attachment := slack.Attachment{
-		Fallback:   message.Attachment.Fallback,
-		Color:      message.Attachment.Color,
-		Pretext:    message.Attachment.Pretext,
-		AuthorName: message.Attachment.AuthorName,
-		AuthorLink: message.Attachment.AuthorLink,
-		AuthorIcon: message.Attachment.AuthorIcon,
-		Title:      message.Attachment.Title,
-		TitleLink:  message.Attachment.TitleLink,
-		Text:       message.Attachment.Text,
-		Fields:     fields,
-		ImageURL:   message.Attachment.ImageURL,
-		MarkdownIn: []string{"text", "pretext", "fields"},
-	}
-
 	postMessage := slack.PostMessageParameters{
-		Username:    message.Name,
-		Attachments: []slack.Attachment{attachment},
-		LinkNames:   1,
+		Username:  message.Name,
+		LinkNames: 1,
 	}
 
 	re := regexp.MustCompile("^:.*:$")
@@ -53,6 +30,32 @@ func (s *Slack) onMessage(message *Message) error {
 		postMessage.IconEmoji = message.Icon
 	} else {
 		postMessage.IconURL = message.Icon
+	}
+
+	if message.Attachment != nil {
+		attachment := slack.Attachment{
+			Fallback:   message.Attachment.Fallback,
+			Color:      message.Attachment.Color,
+			Pretext:    message.Attachment.Pretext,
+			AuthorName: message.Attachment.AuthorName,
+			AuthorLink: message.Attachment.AuthorLink,
+			AuthorIcon: message.Attachment.AuthorIcon,
+			Title:      message.Attachment.Title,
+			TitleLink:  message.Attachment.TitleLink,
+			Text:       message.Attachment.Text,
+			ImageURL:   message.Attachment.ImageURL,
+			MarkdownIn: []string{"text", "pretext", "fields"},
+		}
+		if len(message.Attachment.Fields) > 0 {
+			fields := make([]slack.AttachmentField, len(message.Attachment.Fields))
+			for i := range fields {
+				fields[i].Title = message.Attachment.Fields[i].Title
+				fields[i].Value = message.Attachment.Fields[i].Value
+				fields[i].Short = message.Attachment.Fields[i].Short
+			}
+			attachment.Fields = fields
+		}
+		postMessage.Attachments = []slack.Attachment{attachment}
 	}
 
 	_, _, err := s.Client.PostMessage(message.Channel, message.Message, postMessage)

--- a/slack.go
+++ b/slack.go
@@ -39,7 +39,7 @@ func (s *Slack) onMessage(message *Message) error {
 		Text:       message.Attachment.Text,
 		Fields:     fields,
 		ImageURL:   message.Attachment.ImageURL,
-		// MarkdownIn: []string{"text", "pretext", "fields"},
+		MarkdownIn: []string{"text", "pretext", "fields"},
 	}
 
 	postMessage := slack.PostMessageParameters{


### PR DESCRIPTION
### 概要
- Attachment中(`text`, `pretext`, `fields`)でMarkdownが利用可能になりました。
  - nlopes/slack の更新が必要です。
  - 利用可能な文法は下記を参照してください。  
    https://slack.zendesk.com/hc/en-us/articles/202288908-Formatting-your-messages
- 不要なAttachmentの生成による空行が発生しないよう修正しました。
### サンプル
#### Attachment の Markdown

![image](https://cloud.githubusercontent.com/assets/1488898/7385729/d80179ac-ee85-11e4-85c6-4340dc188fe8.png)

画像のようなPOSTをするには下記のようなコマンドを組み立てます。

``` sh
curl localhost:4979/notice -d "channel=#bot_test" -d "color=#3498db" \
-d "name=shachikun" \
-d "icon=:orca:" \
-d "title=:star2: Attachment Markdown Testing" \
-d "pretext=[Pretext] *bold text* _italic text_ \`fixed-width text\`" \
-d "text=[Text]
%E2%80%A2 *bold text*
%E2%80%A2 _italic text_
%E2%80%A2 \`fixed-width text\`
> block quote
\`\`\`
#include <iostream>
using namespace std%3B
void main() {
    cout << \"hello world\" << endl%3B
}
\`\`\`
" \
-d "field_title[]=Field 1" \
-d "field_value[]=> *bold text* _italic text_ \`fixed-width text\`" \
-d "field_short[]=1" \
-d "field_title[]=Field 2" \
-d "field_value[]=> *bold text* _italic text_ \`fixed-width text\`" \
-d "field_short[]=1"
```
#### 不要な Attachment の生成による空行の修正
- **修正前**  
  ![image](https://cloud.githubusercontent.com/assets/1488898/7385691/5f21f688-ee85-11e4-8fa4-95f2b611bce7.png)
- **修正後**  
  ![image](https://cloud.githubusercontent.com/assets/1488898/7385646/8a84bd52-ee84-11e4-84ca-881dc89011ad.png)
