### PR TITLE
Fix `undefined` error

### DIFF
--- a/slack.go
+++ b/slack.go
@@ -8,7 +8,7 @@ import (
 type Slack struct {
 	Name   string
 	Icon   string
-	Client *slack.Slack
+	Client *slack.Client
 }
 
 func NewSlack(name, icon, token string) *Slack {


### PR DESCRIPTION
I found an error when deploying in heroku button.

```
-----> Fetching custom git buildpack... done
-----> Go app detected
...
...
-----> Installing Mercurial... done
-----> Installing Bazaar... done
-----> Running: go get -tags heroku ./...
# takosan
./slack.go:11: undefined: slack.Slack
```

As described below, the current had changed the type that is returned by the `New` function.

github.com/nlopes/slack
https://github.com/nlopes/slack/commit/16288f9a445cde22e188f3ca72c1919559411e23#diff-e0431040fb990a8da59a206792dfcf7cL40
